### PR TITLE
Fix runtime error for ListViewController in Xcode 6.3

### DIFF
--- a/RandomApp/ListViewController.swift
+++ b/RandomApp/ListViewController.swift
@@ -17,7 +17,7 @@ public class ListViewController: UITableViewController {
     public init(client: RandomClient) {
         self.client = client
         self.numbers = []
-        super.init(style: .Plain)
+        super.init(nibName: nil, bundle: nil)
     }
 
     required public init(coder aDecoder: NSCoder) {


### PR DESCRIPTION
The change is needed because otherwise the application crashes using Xcode 6.3 in iOS 6.3 simulator with the following error:

```
fatal error: use of unimplemented initializer 'init(nibName:bundle:)' for class 'RandomApp.ListViewController'
```
